### PR TITLE
Correct syntax of .readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ create a copy of `config/sequelizeCliConfig.js` that contains your mysql credent
 
 install the latest release of [`lbrycrd`](https://github.com/lbryio/lbrycrd/releases)
 
-start lbrycrdd and leaving running 
+start lbrycrdd and leave running 
 
 ```
 ./lbrycrdd -server -txindex -rpcuser=lbry -rpcpassword=lbry


### PR DESCRIPTION
I changed  "and leaving running" to "and leave running" to make the grammar consistent throughout the doc. I'm excited to create my own spee.ch server for hosting citizen science images for training collective intelligence AI. I love the idea of the library returning as an epicenter for all knowledge and art to mingle and in so-doing, become permanent without risk of censorship or destruction.